### PR TITLE
Mmount ssh keys to laradock user directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
         - ${APP_CODE_PATH_HOST_PLUGINS}:${APP_CODE_PATH_CONTAINER}/wp-content/plugins
         - docker-in-docker:/certs/client
         - ./php-worker/supervisord.d:/etc/supervisord.d
-        - ${LOCAL_SSH}:/root/.ssh
+        - ${LOCAL_SSH}:/home/laradock/.ssh
       extra_hosts:
         - "dockerhost:${DOCKER_HOST_IP}"
       ports:


### PR DESCRIPTION
## Description
The ssh keys have previously been mounted to the root users home directory. The dev containter starts to the laradock user, so the keys should also be mounted to the laradock users.
